### PR TITLE
Update availability of Bookables after creating a Booking

### DIFF
--- a/src/redux/api/actions.js
+++ b/src/redux/api/actions.js
@@ -6,6 +6,7 @@ import {
   normalizeLocations,
   normalizeBookables,
   normalizeBookings,
+  normalizeBooking,
 } from './schema'
 
 import { getAPIEndpoint } from 'Utils'
@@ -72,7 +73,14 @@ export const createBooking = booking => ({
   [RSAA]: {
     endpoint: `${apiEndpoint}/booking`,
     method: 'POST',
-    types: [ 'CREATE_BOOKING_PENDING', 'CREATE_BOOKING_SUCCESS', 'CREATE_BOOKING_FAILURE' ],
+    types: [
+      'CREATE_BOOKING_PENDING',
+      {
+        type: 'CREATE_BOOKING_SUCCESS',
+        payload: (action, state, res) => getJSON(res).then(json => normalizeBooking(json)),
+      },
+      'CREATE_BOOKING_FAILURE',
+    ],
     body: JSON.stringify(booking),
     headers: { 'Content-Type': 'application/json' },
   },
@@ -82,7 +90,15 @@ export const deleteBooking = bookingId => ({
   [RSAA]: {
     endpoint: `${apiEndpoint}/booking/${bookingId}`,
     method: 'DELETE',
-    types: [ 'DELETE_BOOKING_PENDING', 'DELETE_BOOKING_SUCCESS', 'DELETE_BOOKING_FAILURE' ],
+    types: [
+      'DELETE_BOOKING_PENDING',
+      {
+        type: 'DELETE_BOOKING_SUCCESS',
+        // This is enough for our reducer to know which booking to remove from the entities state slice
+        payload: () => bookingId,
+      },
+      'DELETE_BOOKING_FAILURE',
+    ],
   },
 })
 
@@ -90,9 +106,6 @@ export const actionCreators = {
   getAllLocations,
   getAllBookables,
   getAllBookings,
-
   createBooking,
   deleteBooking,
-
-  getBookablesForLocation: getAllBookables,
 }

--- a/src/redux/api/reducer.js
+++ b/src/redux/api/reducer.js
@@ -1,48 +1,50 @@
-import { List, Map, fromJS } from 'immutable'
+import { Map, Set, fromJS } from 'immutable'
 
-import { handleAction, handleActions } from 'redux-actions'
+import { handleActions } from 'redux-actions'
 
-export const locations = handleAction(
-  'GET_LOCATIONS_SUCCESS',
-  (state, action) => {
-    const { entities: { locations }, result } = action.payload
-    return state.withMutations((map) => {
-      map.set('result', List(result))
-      result.forEach(id => map.setIn(['entities', id], Map(locations[id])))
-    })
+const entityState = Map({
+  locations: Map({
+    entities: Map(),
+    result: Set(),
+  }),
+  bookables: Map({
+    entities: Map(),
+    result: Set(),
+  }),
+  bookings: Map({
+    entities: Map(),
+    result: Set(),
+  }),
+})
+
+const updateEntitySlice = (slice, entities, result) => {
+  return slice.withMutations((state) => {
+    state.update('result', set => set.union(result))
+    result.forEach(id => state.setIn(['entities', id], fromJS(entities[id])))
+  })
+}
+
+const updateEntities = entity => (entityState, action) => {
+  const { entities: { [entity]: entities }, result } = action.payload
+  return entityState.update(entity, slice => updateEntitySlice(slice, entities, result))
+}
+
+// TODO: IMPLEMENT ME
+// const removeEntity = entity => (entityState, action) => {}
+
+const entities = handleActions({
+  GET_LOCATIONS_SUCCESS: updateEntities('locations'),
+  GET_BOOKABLES_SUCCESS: updateEntities('bookables'),
+  GET_BOOKINGS_SUCCESS: updateEntities('bookings'),
+  CREATE_BOOKING_SUCCESS: updateEntities('bookings'),
+  DELETE_BOOKING_SUCCESS: (state, action) => {
+    // TODO: remove booking from entityState using id
+    console.log('[DELETE BOOKING] STATE:', state, 'ACTION:', action)
+    return state
   },
-  fromJS({ entities: {}, result: [] })
-)
+}, entityState)
 
-export const bookables = handleAction(
-  'GET_BOOKABLES_SUCCESS',
-  (state, action) => {
-    const { entities: { bookables }, result } = action.payload
-    return state.withMutations((map) => {
-      map.set('result', List(result))
-      result.forEach(id => map.setIn(['entities', id], fromJS(bookables[id])))
-    })
-  },
-  fromJS({ entities: {}, result: [] })
-)
-
-export const bookings = handleAction(
-  'GET_BOOKINGS_SUCCESS',
-  (state, action) => {
-    const { entities: { bookings }, result } = action.payload
-    return state.withMutations((map) => {
-      map.set('result', List(result))
-      result.forEach(id => map.setIn(['entities', id], Map(bookings[id])))
-    })
-  },
-  fromJS({ entities: {}, result: [] })
-)
-
-export const bookingInstance = handleAction(
-  'CREATE_BOOKING_SUCCESS',
-  (state, action) => action.payload,
-  null
-)
+// XXX: DEAD CODE. KILL. KILL. KILL.
 export const requestInProgress = handleActions({
   CREATE_BOOKING_FAILURE: () => false,
   CREATE_BOOKING_PENDING: () => true,
@@ -50,8 +52,6 @@ export const requestInProgress = handleActions({
 }, false)
 
 export const reducer = {
-  locations,
-  bookables,
-  bookings,
+  entities,
   requestInProgress,
 }

--- a/src/redux/api/schema.js
+++ b/src/redux/api/schema.js
@@ -3,12 +3,11 @@ import { normalize, schema } from 'normalizr'
 export const location = new schema.Entity('locations', {})
 
 export const bookable = new schema.Entity('bookables', {}, {
-  processStrategy: ({ id, name, locationId, disposition, bookings }) => ({
+  processStrategy: ({ id, name, locationId, disposition }) => ({
     id,
     name,
     location: locationId,
     disposition,
-    bookings,
   }),
 })
 
@@ -22,7 +21,6 @@ export const booking = new schema.Entity('bookings', {}, {
   }),
 })
 
-bookable.define({ bookings: [ booking ] })
 booking.define({ bookable })
 
 export const locationList = [ location ]
@@ -31,4 +29,9 @@ export const bookingList = [ booking ]
 
 export const normalizeLocations = data => normalize(data, locationList)
 export const normalizeBookables = data => normalize(data, bookableList)
+
 export const normalizeBookings = data => normalize(data, bookingList)
+export const normalizeBooking = (data) => {
+  const { entities, result } = normalize(data, booking)
+  return { entities, result: [ result ] }
+}

--- a/src/redux/api/selectors.js
+++ b/src/redux/api/selectors.js
@@ -1,4 +1,4 @@
-import { Map, List, Set } from 'immutable'
+import { Map, Set } from 'immutable'
 
 import { formValueSelector } from 'redux-form'
 
@@ -9,15 +9,17 @@ import { doesRangeOverlap, formatDate, isSameDay, compareDates } from 'Utils'
 
 // ### Baseline selectors ----------------------------------------------------
 
-export const getBookings = state => state.bookings
+export const getEntities = state => state.entities
+
+export const getBookings = state => getEntities(state).get('bookings')
 export const getBookingIds = state => getBookings(state).get('result').toArray()
 export const getBookingEntities = state => getBookings(state).get('entities', Map())
 
-export const getLocations = state => state.locations
+export const getLocations = state => getEntities(state).get('locations')
 export const getLocationIds = state => getLocations(state).get('result').toArray()
 export const getLocationEntities = state => getLocations(state).get('entities', Map())
 
-export const getBookables = state => state.bookables
+export const getBookables = state => getEntities(state).get('bookables')
 export const getBookableIds = state => getBookables(state).get('result').toArray()
 export const getBookableEntities = state => getBookables(state).get('entities', Map())
 
@@ -68,10 +70,14 @@ export const getLocationTimezone = createGetSelector(getLocationEntity, 'timeZon
 
 export const getBookableEntity = (state, props) => getBookableEntities(state).get(props.id, null)
 
-// export const getBookableId = createGetSelector(getBookableEntity, 'id', null)
+export const getBookableId = createGetSelector(getBookableEntity, 'id', null)
 export const getBookableName = createGetSelector(getBookableEntity, 'name', null)
 export const getBookableDisposition = createGetSelector(getBookableEntity, 'disposition', Map())
-export const getBookableBookings = createGetSelector(getBookableEntity, 'bookings', List())
+
+export const getBookableBookings = createSelector(
+  [ getBookableId, getBookingIds, getBookingEntities ],
+  (bookableId, bookingIds, bookings) => bookingIds.filter(id => bookings.getIn([id, 'bookable']) === bookableId)
+)
 
 export const isBookableClosed = createSelector(
   [ getBookableDisposition ],

--- a/src/redux/booking/reducer.js
+++ b/src/redux/booking/reducer.js
@@ -1,7 +1,8 @@
 import { handleActions } from 'redux-actions'
 
 export const bookingInstance = handleActions({
-  CREATE_BOOKING_SUCCESS: (state, action) => action.payload,
+  // XXX: The return value below is a hack until we no longer need `bookingInstance`
+  CREATE_BOOKING_SUCCESS: (state, action) => action.payload.entities.bookings[action.payload.result[0]],
   CREATE_BOOKING_PENDING: () => null,
 }, null)
 


### PR DESCRIPTION
This involved combining the three distinct `location`, `bookables` and `bookings` state slices into a single `entities` slice, which allows other by-case reducer handlers to access other parts of the entities state slice to perform updates, removals and so on.

Also removed the modeling of `bookings` on bookables and instead prefer to use a selector to retrieve bookings that belong to a bookable.

Reason for the above is that updating the `bookings` list on a `bookable` presented non-standard behaviour that was not really desirable given that the bulk of our API data is flattened pretty much right out the gate - maintaining a list of bookings was irrelevant since we can (and do) derive bookings for a bookable _live_, requiring only a change to the `bookings` entity state slice to trigger a recalculation of memoized selectors.