### PR TITLE
remove document.readyState check before calling loadHandler

### DIFF
--- a/src/components/WindowOpener.jsx
+++ b/src/components/WindowOpener.jsx
@@ -84,7 +84,7 @@ export default class WindowOpener extends Component {
     const loadHandler = () => this.props.onLoaded && this.props.onLoaded(owindow)
 
     owindow.onload = loadHandler
-    owindow.document.readyState === 'complete' && loadHandler()
+    loadHandler()
 
     this.setState({ owindow })
   }


### PR DESCRIPTION
this is preventing firefox users from logging in.

This is a short-term "oh well" fix - I am not certain about any deeper impact this may have - the browser _should_ wait for the document to be ready before calling any event handlers, but apparently both chrome and firefox no longer seem to care, and everything appears to work with the fix below.