### PR TITLE
Fixup svg imports for build

### DIFF
--- a/.jestrc.json
+++ b/.jestrc.json
@@ -1,6 +1,6 @@
 {
   "moduleNameMapper": {
-    "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/test/__mocks__/fileMock.js",
+    "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/test/unit/__mocks__/fileMock.js",
     "^[./a-zA-Z0-9!&$_-]+\\.(css|scss)$": "identity-obj-proxy",
     "^Store(.*)$": "<rootDir>/src/store$1",
     "^History(.*)$": "<rootDir>/src/history$1",

--- a/src/containers/BookingForm.jsx
+++ b/src/containers/BookingForm.jsx
@@ -16,6 +16,9 @@ import { actionCreators, selectors } from 'Redux'
 import Button from 'Components/Button'
 import Loading from 'Components/Loading'
 
+import arrowRightSrc from 'Images/input-arrow-right.svg'
+import closeSrc from 'Images/close.svg'
+
 import {
   addHours,
   isToday,
@@ -158,7 +161,7 @@ const renderSelect = (locations = [], onChange) => (
 const roomSelectToggle = (selectedRoomName = 'Pick A Room') => (
   <div className={styles.roomSelectToggleInput} id={selectedRoomName.replace(/\s/g, '-').toLowerCase()}>
     <span>{selectedRoomName}</span>
-    <img src="images/input-arrow-right.svg" alt="Select a room"/>
+    <img src={arrowRightSrc} alt="Select a room"/>
   </div>
 )
 
@@ -228,11 +231,11 @@ export class BookingForm extends React.Component {
     return (
       <div className={ styles.bookingForm }>
         <Link to="/home" className={ styles.cancel }>
-          <img src="images/close.svg" alt="Closing booking form and go home"/>
+          <img src={closeSrc} alt="Closing booking form and go home"/>
         </Link>
 
         <form onSubmit={ handleSubmit(this.submitBookingForm) }>
-          
+
           <div className={ styles.heading }>
             <h2 className={ styles.title }>Book A Room in { renderSelect(locations, this.clearRoom) }</h2>
           </div>
@@ -247,16 +250,12 @@ export class BookingForm extends React.Component {
             <Field name="end" component={ renderTimePicker } label="End" type="text" validate={ [ required, endAfterStart ] } clearRoom={this.clearRoom} touch={touch} />
           </div>
 
-          
-
           <Field name="bookableId" component={ renderField } type="hidden" label="Room" />
           <a href="#" onClick={(event) => {
             event.preventDefault()
             setBookablesVisible(true)
           }} className={`${styles.roomsToggle} roomsInput`}>{roomSelectToggle(bookableName)}</a>
 
-          {/* <Field name="bookableId" component={ renderField } type="hidden" label={ bookableName || 'Pick a Room' } /> */}
-          
           <Field name="subject" component={ renderField } label="Event Name" type="text" validate={ required } />
 
           <div className={ styles.field }>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,6 +60,7 @@ module.exports = {
       Utils: path.resolve(__dirname, 'src/utils'),
 
       Styles: path.resolve(__dirname, 'src/styles'),
+      Images: path.resolve(__dirname, 'src/images'),
 
       Api: path.resolve(__dirname, 'src/api'),
 


### PR DESCRIPTION
This is the simplest (and most likely, best) "fix" that utilises existing dependencies to force inclusion of SVG (or any other image) assets into the production build of the client code.

Ultimately the fix boils down to `import`ing the required image asset into whichever component requires it and then using the imported name as the value for the `src` attribute on the `img` tag that wants to display said image asset.

The changes below should adequately demonstrate the process.

Additional changes were required to fix jest' ability to mock image assets during tests, which has apparently been broken for quite some time, but since we haven't directly used assets within components before, we never noticed.